### PR TITLE
added page customization fields to audio summary ui

### DIFF
--- a/pkg/api/async/v1/interfaces/types.go
+++ b/pkg/api/async/v1/interfaces/types.go
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
-	Defines everything that makes up the Async API interface
+Defines everything that makes up the Async API interface
 */
 package interfaces
 
 /*
-	Shared definitions
+Shared definitions
 */
 type User struct {
 	Name   string `json:"name,omitempty" validate:"required"`
@@ -85,9 +85,10 @@ type Entity struct {
 }
 
 /*
-	TODO: When exercising the API and description is blank...
+TODO: When exercising the API and description is blank...
 
-	HTTP Code: 400
+HTTP Code: 400
+
 	{
 		"message":"\"description\" is not allowed to be empty"
 	}
@@ -316,8 +317,25 @@ type TextSummaryRequest struct {
 }
 
 type AudioSummaryRequest struct {
-	Name     string `json:"name,omitempty"`
-	AudioURL string `json:"audioUrl,omitempty"`
+	Name                string `json:"name,omitempty"`
+	AudioURL            string `json:"audioUrl,omitempty"`
+	Logo                string `json:"logo,omitempty"`
+	Favicon             string `json:"favicon,omitempty"`
+	Color               Color  `json:"color,omitempty"`
+	Font                Font   `json:"font,omitempty"`
+	SummaryURLExpiresIn int    `json:"summaryURLExpiresIn,omitempty"`
+	ReadOnly            bool   `json:"readOnly,omitempty"`
+	EnableCustomDomain  bool   `json:"enableCustomDomain,omitempty"`
+}
+
+type Color struct {
+	Background     string `json:"background,omitempty"`
+	TopicsFilter   string `json:"topicsFilter,omitempty"`
+	InsightsFilter string `json:"insightsFilter,omitempty"`
+}
+
+type Font struct {
+	Family string `json:"family"`
 }
 
 type VideoSummaryRequest struct {

--- a/pkg/api/async/v1/summaryui.go
+++ b/pkg/api/async/v1/summaryui.go
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
-	Async package for processing Async conversations
+Async package for processing Async conversations
 */
 package async
 
@@ -162,6 +162,7 @@ func (c *Client) GetAudioSummaryUI(ctx context.Context, conversationId string, r
 		c.getQueryParamFromContext(ctx))
 	klog.V(6).Infof("Calling %s\n", URI)
 
+	request.Name = "audio-summary"
 	jsonStr, err := json.Marshal(request)
 	if err != nil {
 		klog.V(1).Infof("json.Marshal failed. Err: %v\n", err)


### PR DESCRIPTION
## What this PR does / why we need it

Adds ability to set custom fields on audio-summary, including logo and favicon

https://docs.symbl.ai/reference/create-summary-ui

<img width="554" alt="Screenshot 2023-09-27 at 10 31 08 AM" src="https://github.com/symblai/symbl-go-sdk/assets/32221114/b1251742-3518-476e-84f7-b66675fd9d15">

