### PR TITLE
Add support to update media url for Insights UI

### DIFF
--- a/examples/call-score/cmd.go
+++ b/examples/call-score/cmd.go
@@ -101,6 +101,16 @@ func main() {
 		// os.Exit(1)
 	}
 
+	// Update Media URL for Insights Details UI
+	newMediaUrl := "https://publicly-accessible-audio-url.mp3"
+	err = asyncClient.UpdateMediaUrlForInsightsDetailsUI(ctx, conversationJob.ConversationID, newMediaUrl)
+	if err == nil {
+		fmt.Printf("Media URL for Insights Details UI updated successfully.\n")
+	} else {
+		fmt.Printf("Update Media URL for Insights Details UI failed. Err: %v\n", err)
+		// os.Exit(1)
+	}
+
 	fmt.Printf("\n\n")
 	fmt.Printf("\n\n")
 

--- a/pkg/api/async/v1/summaryui.go
+++ b/pkg/api/async/v1/summaryui.go
@@ -354,3 +354,64 @@ func (c *Client) GetInsightsDetailsUiURI(ctx context.Context, conversationId str
 	klog.V(6).Infof("async.GetInsightsDetailsUiURI LEAVE\n")
 	return &result, nil
 }
+
+// UpdateMediaUrlForInsightsDetailsUI updates the audio/video URL that will be played in Insights UI
+func (c *Client) UpdateMediaUrlForInsightsDetailsUI(ctx context.Context, conversationId string, mediaUrl string) error {
+    klog.V(6).Infof("async.UpdateMediaUrlForInsightsDetailsUI ENTER\n")
+
+    // checks
+    if ctx == nil {
+        ctx = context.Background()
+    }
+    if conversationId == "" {
+        klog.V(1).Infof("conversationId is empty\n")
+        klog.V(6).Infof("async.UpdateMediaUrlForInsightsDetailsUI LEAVE\n")
+        return ErrInvalidInput
+    }
+    if mediaUrl == "" {
+        klog.V(1).Infof("mediaUrl is empty\n")
+        klog.V(6).Infof("async.UpdateMediaUrlForInsightsDetailsUI LEAVE\n")
+        return ErrInvalidInput
+    }
+
+    // request
+    URI := fmt.Sprintf("%s%s",
+        version.GetAsyncAPI(version.UpdateMediaURI, conversationId), // You'll need to define the endpoint in your version package
+        c.getQueryParamFromContext(ctx))
+    klog.V(6).Infof("Calling %s\n", URI)
+
+    requestBody, err := json.Marshal(map[string]string{
+        "url": mediaUrl,
+    })
+    if err != nil {
+        klog.V(1).Infof("json.Marshal failed. Err: %v\n", err)
+        klog.V(6).Infof("async.UpdateMediaUrlForInsightsDetailsUI LEAVE\n")
+        return err
+    }
+
+    req, err := http.NewRequestWithContext(ctx, "PUT", URI, bytes.NewBuffer(requestBody))
+    if err != nil {
+        klog.V(1).Infof("http.NewRequestWithContext failed. Err: %v\n", err)
+        klog.V(6).Infof("async.UpdateMediaUrlForInsightsDetailsUI LEAVE\n")
+        return err
+    }
+
+    // execute request
+    resp, err := c.Client.Do(req)
+    if err != nil {
+        klog.V(1).Infof("Request execution failed. Err: %v\n", err)
+        klog.V(6).Infof("async.UpdateMediaUrlForInsightsDetailsUI LEAVE\n")
+        return err
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        klog.V(1).Infof("HTTP Code: %v\n", resp.StatusCode)
+        klog.V(6).Infof("async.UpdateMediaUrlForInsightsDetailsUI LEAVE\n")
+        return fmt.Errorf("HTTP Code: %v", resp.StatusCode)
+    }
+
+    klog.V(3).Infof("Update MediaUrl For InsightsUI succeeded\n")
+    klog.V(6).Infof("async.UpdateMediaUrlForInsightsDetailsUI LEAVE\n")
+    return nil
+}

--- a/pkg/api/version/async-version.go
+++ b/pkg/api/version/async-version.go
@@ -52,6 +52,7 @@ const (
 	// Insights Ui
 	InsightsListUiURI    string = "https://api.symbl.ai/%s/conversations/experiences/insights/list?includeCallScore=true"
 	InsightsDetailsUiURI string = "https://api.symbl.ai/%s/conversations/experiences/insights/details/%s?includeCallScore=true"
+	UpdateMediaURI string = "https://api.symbl.ai/%s/conversations/%s/experience/url"
 
 	// Conversations
 	ConversationsURI string = "https://api.symbl.ai/%s/conversations"


### PR DESCRIPTION
This PR introduces a new PUT endpoint for updating the media URL that's played for the audio player within the Insights UI.
