### PR TITLE
Update CallScoreCriteria Score type to float64

### DIFF
--- a/pkg/api/async/v1/interfaces/types.go
+++ b/pkg/api/async/v1/interfaces/types.go
@@ -467,7 +467,7 @@ type CallScoreResult struct {
 // CallScoreCriteria
 type CallScoreCriteria struct {
 	Name     string            `json:"name"`
-	Score    string            `json:"score"`
+	Score    float64           `json:"score"`
 	Summary  string            `json:"summary"`
 	Feedback CallScoreFeedback `json:"feedback"`
 }


### PR DESCRIPTION
This PR updates the Score field type in the CallScoreCriteria struct from string to float64 to address a type mismatch error.