### PR TITLE
Update CallScoreResult Score type to float64

### DIFF
--- a/pkg/api/async/v1/interfaces/types.go
+++ b/pkg/api/async/v1/interfaces/types.go
@@ -459,7 +459,7 @@ type TeardownMessage struct {
 
 // CallScoreResult
 type CallScoreResult struct {
-	Score    string              `json:"score"`
+	Score    float64             `json:"score"`
 	Summary  string              `json:"summary"`
 	Criteria []CallScoreCriteria `json:"criteria"`
 }


### PR DESCRIPTION
This PR updates the Score field type in the CallScoreResult struct from string to float64 to address a type mismatch error.